### PR TITLE
RapidClientFactory.NewRapidClient is now thread safe

### DIFF
--- a/eWAY.Rapid.Tests/IntegrationTests/MultiThreadedTests.cs
+++ b/eWAY.Rapid.Tests/IntegrationTests/MultiThreadedTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using eWAY.Rapid.Enums;
+using eWAY.Rapid.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Internal = eWAY.Rapid.Internals.Models;
+namespace eWAY.Rapid.Tests.IntegrationTests
+{
+    [TestClass]
+    public class MultiThreadedTests : SdkTestBase
+    {
+        [TestMethod]
+        public void Multithread_CreatingMultipleClientsInManyThreads_ReturnsValidData()
+        {
+            RunInMultipleThreads(20, () =>
+            {
+
+                IRapidClient client = CreateRapidApiClient();
+                Transaction transaction = new Transaction()
+                {
+                    Customer = TestUtil.CreateCustomer(),
+                    PaymentDetails = new PaymentDetails()
+                    {
+                        TotalAmount =  200
+                    },
+                    TransactionType = TransactionTypes.MOTO,
+                    
+
+                };
+                CreateTransactionResponse response = 
+                    client.Create(PaymentMethod.Direct, transaction);
+                });
+
+            
+        }
+
+
+        private void RunInMultipleThreads(int threadCount, Action action)
+        {
+            List<Thread> startedThreads = new List<Thread>();
+            for (int i = 0; i < threadCount; i++)
+            {
+                Thread thread = new Thread(() => action());
+                startedThreads.Add(thread);
+                thread.Start();
+
+            }
+            foreach (Thread thread in startedThreads)
+            {
+                thread.Join();
+            }
+            
+        }
+
+
+    }
+}

--- a/eWAY.Rapid.Tests/eWAY.Rapid.Tests.csproj
+++ b/eWAY.Rapid.Tests/eWAY.Rapid.Tests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="IntegrationTests\CreateCustomerTests.cs" />
     <Compile Include="IntegrationTests\CreateTransactionTests.cs" />
     <Compile Include="IntegrationTests\DirectRefundTests.cs" />
+    <Compile Include="IntegrationTests\MultiThreadedTests.cs" />
     <Compile Include="IntegrationTests\PreAuthTests.cs" />
     <Compile Include="IntegrationTests\QueryCustomerTests.cs" />
     <Compile Include="IntegrationTests\SettlementSearchTests.cs" />

--- a/eWAY.Rapid/Internals/Services/MappingService.cs
+++ b/eWAY.Rapid/Internals/Services/MappingService.cs
@@ -30,12 +30,22 @@ namespace eWAY.Rapid.Internals.Services
             return Mapper.Map<TSource, TDest>(obj);
         }
 
+        private static bool _mappingsHaveBeenRegistered = false;
+        private static readonly object _registerMappingsMutex = new object();
+
         public static void RegisterMapping()
         {
-            RegisterRequestMapping();
-            RegisterResponseMapping();
-            RegisterCustomMapping();
-            RegisterEntitiesMapping();
+            if (_mappingsHaveBeenRegistered) return;
+            lock (_registerMappingsMutex)
+            {
+                if (!_mappingsHaveBeenRegistered)
+                {
+                    RegisterRequestMapping();
+                    RegisterResponseMapping();
+                    RegisterCustomMapping();
+                    RegisterEntitiesMapping();
+                }
+            }
         }
 
         public static void RegisterRequestMapping()

--- a/eWAY.Rapid/Internals/Services/MappingService.cs
+++ b/eWAY.Rapid/Internals/Services/MappingService.cs
@@ -44,6 +44,7 @@ namespace eWAY.Rapid.Internals.Services
                     RegisterResponseMapping();
                     RegisterCustomMapping();
                     RegisterEntitiesMapping();
+                    _mappingsHaveBeenRegistered = true;
                 }
             }
         }


### PR DESCRIPTION
This fixed a problem where using RapidClientFactory.NewRapidClient would cause exceptions from AutoMapper to be thrown. This occurred as `Mapper.CreateMap` is not thread safe (see [this thread](http://automapper.codeplex.com/workitem/3197)).

The test I added failed about half the time with the old code, and never fails now with the supplied fix.

---

A related problem (not fixed by these changes) is Automapper version 4.1.1 fails the new multithreaded test about 20% of the time. I'm not sure what the problem is there, but using 3.3.1 fixed the issue. [The eWAY.Rapid nuget package](https://www.nuget.org/packages/eWAY.Rapid/) has a dependency range for AutoMapper of  (>= 3.3.1 && <= 4.1.1) so this can result in problems. I haven't investigated if any versions of Automapper between 3.3.1 and 4.1.1, or versions after 4.1.1 work. 
